### PR TITLE
fix: remove trailing slashes from routes to fix CORS redirection issue

### DIFF
--- a/app/routes/project_issues.py
+++ b/app/routes/project_issues.py
@@ -37,7 +37,7 @@ from app.models import (
 bp = Blueprint("project_issues", __name__)
 
 
-@bp.route("/", methods=["GET"])
+@bp.route("", methods=["GET"])
 @jwt_auth.check_session_and_authorization()
 def get_issues(project_uuid: str) -> Response:
     """Fetches a paginated list of issues for a specified project.
@@ -64,7 +64,7 @@ def get_issues(project_uuid: str) -> Response:
         return jsonify({"status": "error", "message": "Failed to fetch data"}), 500
 
 
-@bp.route("/", methods=["DELETE"])
+@bp.route("", methods=["DELETE"])
 @jwt_auth.check_session_and_authorization()
 def delete_issues(project_uuid: str) -> Response:
     """Deletes all issues for a specified project.

--- a/app/routes/project_users.py
+++ b/app/routes/project_users.py
@@ -25,7 +25,7 @@ from app.models import (
 bp = Blueprint("project_users", __name__)
 
 
-@bp.route("/", methods=["GET"])
+@bp.route("", methods=["GET"])
 @jwt_auth.check_session_and_authorization(root_required=True)
 def get_project_users(project_uuid: str) -> Response:
     """Fetches all users associated with a specified project.
@@ -51,7 +51,7 @@ def get_project_users(project_uuid: str) -> Response:
         )
 
 
-@bp.route("/", methods=["POST"])
+@bp.route("", methods=["POST"])
 @jwt_auth.check_session_and_authorization(root_required=True)
 def add_project_user(project_uuid: str) -> Response:
     """Adds a user to a specified project.

--- a/app/routes/projects.py
+++ b/app/routes/projects.py
@@ -27,7 +27,7 @@ from app.models import (
 bp = Blueprint("projects", __name__)
 
 
-@bp.route("/", methods=["GET"])
+@bp.route("", methods=["GET"])
 @jwt_auth.check_session_and_authorization(root_required=True)
 def get_projects() -> Response:
     """Fetches a paginated list of all projects.
@@ -51,7 +51,7 @@ def get_projects() -> Response:
         return jsonify({"status": "error", "message": "Failed to fetch projects"}), 500
 
 
-@bp.route("/", methods=["POST"])
+@bp.route("", methods=["POST"])
 @jwt_auth.check_session_and_authorization(root_required=True)
 def create_project() -> Response:
     """Creates a new project with a unique project ID.

--- a/app/routes/users.py
+++ b/app/routes/users.py
@@ -33,7 +33,7 @@ from app.utils import is_valid_email
 bp = Blueprint("users", __name__)
 
 
-@bp.route("/", methods=["GET"])
+@bp.route("", methods=["GET"])
 @jwt_auth.check_session_and_authorization(root_required=True)
 def get_users() -> Response:
     """Fetches a list of all users.
@@ -50,7 +50,7 @@ def get_users() -> Response:
         return jsonify({"status": "error", "message": "Failed to fetch users"}), 500
 
 
-@bp.route("/", methods=["POST"])
+@bp.route("", methods=["POST"])
 @jwt_auth.check_session_and_authorization(root_required=True)
 def create_user() -> Response:
     """Creates a new user with specified attributes.

--- a/app/routes/webhook.py
+++ b/app/routes/webhook.py
@@ -3,7 +3,7 @@ from flask import jsonify, Blueprint, Response
 bp = Blueprint("webhook", __name__)
 
 
-@bp.route("/", methods=["POST"])
+@bp.route("", methods=["POST"])
 def receive_webhook() -> Response:
     """
     Receives a webhook POST request.


### PR DESCRIPTION
In all routes that ended in "/", i.e. they were meant to be the same as the url_prefix of their respective blueprint, I removed the trailing "/" to fix the CORS redirection issue. 